### PR TITLE
Add `ttlOverride` to `RequestCDN`

### DIFF
--- a/src/cdn.ts
+++ b/src/cdn.ts
@@ -36,9 +36,12 @@ export interface RequestCDN {
 /**
  * Represents a CDN as returned by the Traffic Ops API in responses.
  */
-export interface ResponseCDN extends RequestCDN {
+export interface ResponseCDN {
+	dnssecEnabled: boolean;
+	domainName: string;
 	readonly id: number;
 	readonly lastUpdated: Date;
+	name: string;
 }
 
 /** Represents a CDN. */

--- a/src/cdn.ts
+++ b/src/cdn.ts
@@ -26,6 +26,11 @@ export interface RequestCDN {
 	domainName:    string;
 	/** The name of the CDN. */
 	name:          string;
+	/**
+	 * A TTL (Time To Live) value, in seconds, that, if set, overrides all set
+	 * TTL values on Delivery Services in this CDN.
+	 */
+	ttlOverride?: number | null;
 }
 
 /**

--- a/src/cdn.ts
+++ b/src/cdn.ts
@@ -31,12 +31,9 @@ export interface RequestCDN {
 /**
  * Represents a CDN as returned by the Traffic Ops API in responses.
  */
-export interface ResponseCDN {
-	dnssecEnabled: boolean;
-	domainName: string;
+export interface ResponseCDN extends RequestCDN {
 	readonly id: number;
 	readonly lastUpdated: Date;
-	name: string;
 }
 
 /** Represents a CDN. */

--- a/src/cdn.ts
+++ b/src/cdn.ts
@@ -30,7 +30,7 @@ export interface RequestCDN {
 	 * A TTL (Time To Live) value, in seconds, that, if set, overrides all set
 	 * TTL values on Delivery Services in this CDN.
 	 */
-	ttlOverride?: number | null;
+	ttlOverride?: number;
 }
 
 /**

--- a/src/cdn.ts
+++ b/src/cdn.ts
@@ -30,7 +30,7 @@ export interface RequestCDN {
 	 * A TTL (Time To Live) value, in seconds, that, if set, overrides all set
 	 * TTL values on Delivery Services in this CDN.
 	 */
-	ttlOverride?: number;
+	ttlOverride: number | null;
 }
 
 /**
@@ -42,6 +42,7 @@ export interface ResponseCDN {
 	readonly id: number;
 	readonly lastUpdated: Date;
 	name: string;
+	ttlOverride?: number;
 }
 
 /** Represents a CDN. */


### PR DESCRIPTION
This PR adds the `ttlOverride` field to the `RequestCDN` interface.

~This PR also makes `ResponseCDN` extend `RequestCDN` instead of redeclaring fields.~