### PR TITLE
Add layered profile support to Servers

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -208,7 +208,7 @@ export interface ResponseServer {
 	 */
 	physLocationId: number;
 	/** The Profile used by the Server. */
-	profile: string;
+	profile: string | null;
 	/**
 	 * A description of the Profile used by the Server.
 	 *
@@ -216,7 +216,7 @@ export interface ResponseServer {
 	 * Profile description entirely, as it's trivially deduced from Profile
 	 * identity.
 	 */
-	profileDesc: string;
+	profileDesc: string | null;
 	/**
 	 * An integral, unique identifier for the Profile used by the Server.
 	 *
@@ -518,10 +518,11 @@ export interface ServerDetails  {
 	mgmtIpNetmask: string;
 	offlineReason: string;
 	physLocation: string;
-	profile: string;
+	profile: string | null;
 	/** @deprecated This has been removed from the latest API version. */
-	profileDesc: string;
+	profileDesc: string | null;
 	/** @deprecated this has no known purpose, and you shouldn't invent one. */
+	profileNames: Array<string>;
 	rack: string;
 	routerHostName: string;
 	routerPortName: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -223,7 +223,11 @@ export interface ResponseServer {
 	 * @deprecated In the latest API version, a server's Profile is identified
 	 * only by name, not unique, integral identifier.
 	 */
-	profileId: number;
+	profileId: number | null;
+	/**
+	 * An _ordered_ array of strings representing the Profiles used by this server
+	 */
+	profileNames: Array<string>;
 	/** Whether or not revalidations are pending for this Server. */
 	revalPending: boolean;
 	/**
@@ -331,7 +335,11 @@ export interface RequestServer {
 	 * @deprecated In the latest API version, a server's Profile is identified
 	 * only by name, not unique, integral identifier.
 	 */
-	profileId: number;
+	profileId: number | null;
+	/**
+	 * An _ordered_ array of strings representing the Profiles used by this server
+	 */
+	profileNames: Array<string>;
 	/**
 	 * Legacy field with no purpose.
 	 *

--- a/src/server.ts
+++ b/src/server.ts
@@ -203,28 +203,6 @@ export interface ResponseServer {
 	/** The physical location in which the Server resides. */
 	physLocation: string;
 	/**
-	 * An integral, unique identifier for the physical location in which the
-	 * Server resides.
-	 */
-	physLocationId: number;
-	/** The Profile used by the Server. */
-	profile: string | null;
-	/**
-	 * A description of the Profile used by the Server.
-	 *
-	 * @deprecated Future representations of Server objects will drop the
-	 * Profile description entirely, as it's trivially deduced from Profile
-	 * identity.
-	 */
-	profileDesc: string | null;
-	/**
-	 * An integral, unique identifier for the Profile used by the Server.
-	 *
-	 * @deprecated In the latest API version, a server's Profile is identified
-	 * only by name, not unique, integral identifier.
-	 */
-	profileId: number | null;
-	/**
 	 * An _ordered_ array of strings representing the Profiles used by this server
 	 */
 	profileNames: Array<string>;
@@ -329,13 +307,6 @@ export interface RequestServer {
 	 * Server resides.
 	 */
 	physLocationId: number;
-	/**
-	 * An integral, unique identifier for the Profile used by the Server.
-	 *
-	 * @deprecated In the latest API version, a server's Profile is identified
-	 * only by name, not unique, integral identifier.
-	 */
-	profileId: number | null;
 	/**
 	 * An _ordered_ array of strings representing the Profiles used by this server
 	 */
@@ -518,11 +489,8 @@ export interface ServerDetails  {
 	mgmtIpNetmask: string;
 	offlineReason: string;
 	physLocation: string;
-	profile: string | null;
-	/** @deprecated This has been removed from the latest API version. */
-	profileDesc: string | null;
-	/** @deprecated this has no known purpose, and you shouldn't invent one. */
 	profileNames: Array<string>;
+	/** @deprecated this has no known purpose, and you shouldn't invent one. */
 	rack: string;
 	routerHostName: string;
 	routerPortName: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -203,6 +203,11 @@ export interface ResponseServer {
 	/** The physical location in which the Server resides. */
 	physLocation: string;
 	/**
+	* An integral, unique identifier for the physical location in which the
+	* Server resides.
+	*/
+	physLocationId: number;
+	/**
 	 * An _ordered_ array of strings representing the Profiles used by this server
 	 */
 	profileNames: Array<string>;


### PR DESCRIPTION
This adds the missing `profileNames` property to both `Server` objects for the purposes of layered profiles.