### PR TITLE
Remove artificial restriction that topology parents can only have 2 or fewer parents

### DIFF
--- a/src/topology.ts
+++ b/src/topology.ts
@@ -21,7 +21,7 @@
  */
 export interface RequestTopologyNode {
 	cachegroup: string;
-	parents?: [number, number] | [number] | [] | null;
+	parents?: Array<number> | null;
 }
 
 /**
@@ -29,7 +29,7 @@ export interface RequestTopologyNode {
  */
 export interface ResponseTopologyNode {
 	cachegroup: string;
-	parents: [number, number] | [number] | null;
+	parents: Array<number>;
 }
 
 /**


### PR DESCRIPTION
Topology nodes can have an arbitrary number of parents. Traffic Portal can only handle a maximum of 2 parents, but that is an an application-level restriction, not a data type restriction.